### PR TITLE
JB mods

### DIFF
--- a/system.tex
+++ b/system.tex
@@ -95,7 +95,7 @@ modifications of the General Theory of Relativity, will require
 percent level measurements of both the cosmic expansion and the growth
 of dark matter structure as a function of redshift.  Any given
 cosmological probe is sensitive to, and thus constrains degenerate
-combinations of, several cosmological parameters.  Therefore the most robust
+combinations of, several cosmological and astrophysical/systematic parameters.  Therefore the most robust
 cosmological constraints are the result of using interlocking combinations
 of probes. The most powerful probes include weak gravitational lens cosmic shear (WL), galaxy clustering and baryon
 acoustic oscillations (LSS),
@@ -110,7 +110,7 @@ Meanwhile, there are a number of astrophysical probes of the properties
 of dark matter worth exploring, including, for example, merging clusters
 and mass density profiles in clusters and galaxies (both accessible
 through their weak and strong lensing effects in combination with
-measurments of their dynamics, stellar mass, and X-ray emission), dwarf
+measurements of their dynamics, stellar mass, and X-ray emission), dwarf
 satellite galaxies (both their abundance and gamma ray emission), and
 the subtle perturbations of stellar streams.
 
@@ -199,7 +199,7 @@ dark energy clustering or anisotropic stresses). The cross-correlation
 of the three-dimensional
 mass distribution (as probed by HI in SKA, or galaxies in DESI and PFS) with the gravitational growth
 probed by tomographic shear in LSST will be complementary way to constrain dark energy
-properties beyond simply characterizing its equation of state.
+properties beyond simply characterizing its equation of state and to test the underlying theory of gravity.
 
 
 


### PR DESCRIPTION
Some minor updates to section 2.1 (system.tex).
- fixed a typo
- added mention of combining probes for astrophysics/systematics degeneracy
- mentioned modified gravity in addition to dark energy as value of combining LSST with other surveys

Also, a few comments/questions related to section 4.1. To avoid confusion, I have not yet altered science.tex but would be happy to do so:
- "galaxy-mass correlation function" is ambiguous. (I also commented about this in @damonge PR)
- shear peaks could be included in "higher-order shear statistics"
- Do we want to add a bullet about standard sirens? LSST will (hopefully) find many optical counterparts. I'm probably not the best person to write this bullet point.